### PR TITLE
:alien: disable fragmentOutgoingMessages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,8 @@ module.exports = class CQWebsocket extends $Callable {
     this._qq = $safe.int(parseInt(qq))
 
     this._eventBus = new $CQEventBus(this)
-    this._eventClient = this._event ? new $WebsocketClient() : null
-    this._apiClient = this._api ? new $WebsocketClient() : null
+    this._eventClient = this._event ? new $WebsocketClient({ fragmentOutgoingMessages: false }) : null
+    this._apiClient = this._api ? new $WebsocketClient({ fragmentOutgoingMessages: false }) : null
 
     if (this._eventClient) {
       this._eventClient


### PR DESCRIPTION
因为当前 cqhttp 对 websocket 不完整的支持 https://github.com/richardchien/coolq-http-api/issues/85 

在 websocket-node 默认的配置下 https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md 超过 16KiB 的消息就都发不出去

暂时禁用该选项来确保正常工作，等 cqhttp 如果改好了可以再打开